### PR TITLE
Fix long casting bug

### DIFF
--- a/schlage.groovy
+++ b/schlage.groovy
@@ -491,7 +491,7 @@ def change_lock_state(deviceId, locked) {
 
 def get_logs(deviceId) {
     def path = "devices/${deviceId}/logs"
-    state.last_log = state.last_log ?: Long(0L)
+    state.last_log = state.last_log ?: 0L
     debug(state.users)
     schlage_api(path, [sort: 'desc', limit: 10], 'GET') {
         json = it.data


### PR DESCRIPTION
I was seeing this error during initialization:

groovy.lang.MissingMethodException: No signature of method: user_app_schwark_Schlage_WiFi_Locks_163.Long() is applicable for argument types: (java.lang.Long) values: [0]
Possible solutions: run(), run(), any(), find(), lock(java.lang.Object), wait(long) on line 494 (method updated)

As result, only one of my three locks got added as a device. This lines up with several reports here: https://community.hubitat.com/t/release-schlage-wifi-lock-support/123604/26

I have zero Groovy experience, but 0L is a long literal according to https://groovy-lang.org/syntax.html#_number_type_suffixes - there should be no need for a cast

After making this change, all my locks were successfully added as devices.